### PR TITLE
Added CI configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,17 @@ before_script:
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test ;
       sudo add-apt-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main" ;
       sudo apt-get update ;
-    fi
-  - if [ "$CXX" = "g++" ]; then
-      sudo apt-get install -y --force-yes g++-6 ;
-      export CC=gcc-6 ;
-      export CXX=g++-6 ;
-    fi
-  - if [ "$CXX" = "clang++" ]; then
-      sudo apt-get install -y --force-yes g++-6 ;
-      sudo apt-get install -y --force-yes clang-4.0 ;
-      export CC=clang-4.0 ;
-      export CXX=clang++-4.0 ;
+      if [ "$CXX" = "g++" ]; then
+         sudo apt-get install -y --force-yes g++-6 ;
+         export CC=gcc-6 ;
+         export CXX=g++-6 ;
+      fi ;
+      if [ "$CXX" = "clang++" ]; then
+         sudo apt-get install -y --force-yes g++-6 ;
+         sudo apt-get install -y --force-yes clang-4.0 ;
+         export CC=clang-4.0 ;
+         export CXX=clang++-4.0 ;
+      fi ;
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+
+os:
+  - linux
+  - osx
+
+dist: trusty
+sudo: required
+
+env:
+  matrix:
+    # The CMake setup does not afford testing in Release mode yet
+    # - BUILDTYPE=Release
+    - BUILDTYPE=Debug
+
+matrix:
+  exclude:
+    # gcc is just an alias for clang on OS X, so remove the rsp. build for now
+    - os: osx
+      compiler: gcc
+
+# Note: For clang builds, a gcc-6 environment is set up as well so that a
+# C++14-compliant libstdc++ can be used.
+before_script:
+  - if [ `uname` = "Linux" ]; then
+      wget -nv -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add - ;
+      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test ;
+      sudo add-apt-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main" ;
+      sudo apt-get update ;
+    fi
+  - if [ "$CXX" = "g++" ]; then
+      sudo apt-get install -y --force-yes g++-6 ;
+      export CC=gcc-6 ;
+      export CXX=g++-6 ;
+    fi
+  - if [ "$CXX" = "clang++" ]; then
+      sudo apt-get install -y --force-yes g++-6 ;
+      sudo apt-get install -y --force-yes clang-4.0 ;
+      export CC=clang-4.0 ;
+      export CXX=clang++-4.0 ;
+    fi
+
+script:
+  - mkdir -p ../build
+  - cd ../build
+  - cmake -DCMAKE_BUILD_TYPE=${BUILDTYPE} ../state_ptr
+  - cmake --build . -- -j2
+  - ctest -V

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(StatePointer)
 
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.2.2)
 
 #==============================================================================
 # Setup for compiler toolchain.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+image: Visual Studio 2017
+
+init:
+  - git config --global core.autocrlf input
+
+clone_folder: C:\projects\repos\state_ptr
+
+platform:
+  - x64
+  - x86
+
+environment:
+  global:
+    REPO_DIR: C:\projects\repos
+    INSTALLATION_DIR: C:\projects\installation
+
+configuration:
+  # The CMake setup does not afford testing in Release mode yet
+  # - Release
+  - Debug
+
+build_script:
+  - IF "%PLATFORM%" == "x64" ( SET CMAKE_GENERATOR="Visual Studio 15 2017 Win64")
+  - IF "%PLATFORM%" == "x86" ( SET CMAKE_GENERATOR="Visual Studio 15 2017")
+
+  # Build and test state_ptr
+  - cd %REPO_DIR%\state_ptr
+  - git submodule init
+  - git submodule update
+  - mkdir ..\build
+  - cd ..\build
+  - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALLATION_DIR%  ..\state_ptr
+  - cmake --build . --config %CONFIGURATION%
+  - ctest -V -C %CONFIGURATION%
+
+build:
+  verbosity: minimal
+
+test: off

--- a/testsrc/CMakeLists.txt
+++ b/testsrc/CMakeLists.txt
@@ -18,19 +18,21 @@ target_include_directories(unit_tests
 
 target_link_libraries(unit_tests gtest gtest_main)
 
-target_compile_options(unit_tests
-	PUBLIC
-		-O0             # disable optimizations as they screw testing
-		-fno-inline -O0 # ^--- see above
+if(COMPILING_WITH_GNULIKE)
+	target_compile_options(unit_tests
+		PUBLIC
+			-O0             # disable optimizations as they screw testing
+			-fno-inline -O0 # ^--- see above
 
-		-Wall
-		-Wextra
-		-Wpedantic
-		-Wconversion
-		-Wsign-conversion
+			-Wall
+			-Wextra
+			-Wpedantic
+			-Wconversion
+			-Wsign-conversion
 
-		-pedantic-errors # turns pedantic warnings into errors
-)
+			-pedantic-errors # turns pedantic warnings into errors
+	)
+endif()
 
 add_test(
 	NAME


### PR DESCRIPTION
This PR adds automated testing and building with Travis and AppVeyor. The Travis configuration is still somewhat rough: the required clang and gcc upgrades [could be done more succinctly](https://docs.travis-ci.com/user/languages/cpp/#C11-C%2B%2B11-(and-Beyond)-and-Toolchain-Versioning). However, that [didn't work out so well](https://github.com/fkutzner/state_ptr/commits/ci).